### PR TITLE
Fix Alt+Tab with fullscreen FBOs

### DIFF
--- a/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
+++ b/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
@@ -283,6 +283,20 @@ namespace Microsoft.Xna.Framework
                             keys.Remove(key);
                         }
                     }
+
+                    // Active window
+                    else if (evt.type == SDL.SDL_EventType.SDL_WINDOWEVENT)
+                    {
+                        if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED)
+                        {
+                            // If we alt-tab away, we lose the 'fullscreen desktop' flag on some WMs
+                            SDL.SDL_SetWindowFullscreen(INTERNAL_sdlWindow, (uint) INTERNAL_sdlWindowFlags_Next);
+                        }
+                        else if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST)
+                        {
+                            SDL.SDL_SetWindowFullscreen (INTERNAL_sdlWindow, 0);
+                        }
+                    }
                     
                     // Quit
                     else if (evt.type == SDL.SDL_EventType.SDL_QUIT)


### PR DESCRIPTION
Basically, if you alt-tabbed out of a fullscreen game and alt-tabbed back in, the game would run windowed at the wrong resolution. This patch simply switches to windowed mode on focus lost and back to fullscreen on focus gained.
