### PR TITLE
Scale mouse input when using FBOs

### DIFF
--- a/MonoGame.Framework/SDL2/Input/SDL2_Mouse.cs
+++ b/MonoGame.Framework/SDL2/Input/SDL2_Mouse.cs
@@ -68,7 +68,12 @@ namespace Microsoft.Xna.Framework.Input
             get;
             set;
         }
-        
+
+        internal static int INTERNAL_BackbufferWidth = 800;
+        internal static int INTERNAL_BackbufferHeight = 600;
+        internal static int INTERNAL_WindowWidth = 800;
+        internal static int INTERNAL_WindowHeight = 600;
+
         #endregion
 
         #region Public interface
@@ -81,7 +86,10 @@ namespace Microsoft.Xna.Framework.Input
         {
             int x, y;
 			uint flags = SDL.SDL_GetMouseState(out x, out y);
-   
+  
+            x = (int)((double)x * INTERNAL_BackbufferWidth / INTERNAL_WindowWidth);
+            y = (int)((double)y * INTERNAL_BackbufferHeight / INTERNAL_WindowHeight);
+
             State.X = x;
             State.Y = y;
             
@@ -101,6 +109,8 @@ namespace Microsoft.Xna.Framework.Input
         /// <param name="y">Relative vertical position of the cursor.</param>
         public static void SetPosition(int x, int y)
         {
+            x = (int)((double)x * INTERNAL_WindowWidth / INTERNAL_BackbufferWidth);
+            y = (int)((double)y * INTERNAL_WindowHeight / INTERNAL_BackbufferHeight);
             State.X = x;
             State.Y = y;
             

--- a/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
+++ b/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
@@ -296,6 +296,12 @@ namespace Microsoft.Xna.Framework
                         {
                             SDL.SDL_SetWindowFullscreen (INTERNAL_sdlWindow, 0);
                         }
+                        else if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED ||
+                                 evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED)
+                        {
+                            Mouse.INTERNAL_WindowWidth = evt.window.data1;
+                            Mouse.INTERNAL_WindowHeight = evt.window.data2;
+                        }
                     }
                     
                     // Mouse Wheel
@@ -421,6 +427,8 @@ namespace Microsoft.Xna.Framework
             GL.BindTexture(TextureTarget.Texture2D, 0);
             INTERNAL_glFramebufferWidth = 800;
             INTERNAL_glFramebufferHeight = 600;
+            Mouse.INTERNAL_BackbufferWidth = 800;
+            Mouse.INTERNAL_BackbufferHeight = 600;
         }
         
         #endregion
@@ -491,6 +499,8 @@ namespace Microsoft.Xna.Framework
             );
             INTERNAL_glFramebufferWidth = clientWidth;
             INTERNAL_glFramebufferHeight = clientHeight;
+            Mouse.INTERNAL_BackbufferWidth = clientWidth;
+            Mouse.INTERNAL_BackbufferHeight = clientHeight;
         }
         
         #endregion


### PR DESCRIPTION
This patch scales the mouse input such that the game thinks it's running at the backbuffer resolution.
