### PR TITLE
Write the shader link errors to disk instead of the console...

### DIFF
--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
 #if !GLES
                 var log = GL.GetProgramInfoLog(program);
-                Console.WriteLine(log);
+                GraphicsExtensions.LogToFile(log);
 #endif
                 throw new InvalidOperationException("Unable to link effect program");
             }


### PR DESCRIPTION
This is probably important actually hmmm
