### PR TITLE
Fix for HumbleBugs #795

### DIFF
--- a/MonoGame.Framework/SDL2/Media/VideoPlayer.cs
+++ b/MonoGame.Framework/SDL2/Media/VideoPlayer.cs
@@ -656,9 +656,6 @@ namespace Microsoft.Xna.Framework.Media
         {
             checkDisposed();
             
-            playerThread = new Thread(new ThreadStart(this.RunVideo));
-            audioDecoderThread = new Thread(new ThreadStart(this.DecodeAudio));
-            
             // We need to assign this regardless of what happens next.
             Video = video;
             
@@ -672,10 +669,13 @@ namespace Microsoft.Xna.Framework.Media
             }
             
             // In rare cases, the thread might still be going. Wait until it's done.
-            if (playerThread.IsAlive)
+            if (playerThread != null && playerThread.IsAlive)
             {
                 Stop();
             }
+
+            playerThread = new Thread(new ThreadStart(this.RunVideo));
+            audioDecoderThread = new Thread(new ThreadStart(this.DecodeAudio));
             
             // Update the player state now, for the thread we're about to make.
             State = MediaState.Playing;


### PR DESCRIPTION
Since we're reusing the VideoPlayer instance, we should create the playerThread and audioDecoderThread in the Play function instead of during VideoPlayer instantiation. This fixes a crash when calling Play for a second time in the same VideoPlayer instance.

I ran this a bunch of times running the test case from bug #795 without any crashes.
