### PR TITLE
TextInput fix on x86 Windows

### DIFF
--- a/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
+++ b/MonoGame.Framework/SDL2/SDL2_GameWindow.cs
@@ -392,9 +392,9 @@ namespace Microsoft.Xna.Framework
                     {
                         string text;
                         unsafe { text = new string(evt.text.text); }
-                        for (int i = 0; i < text.Length; i++)
+                        if (text.Length > 0)
                         {
-                            OnTextInput(evt, new TextInputEventArgs(text[i]));
+                            OnTextInput(evt, new TextInputEventArgs(text[0]));
                         }
                     }
 


### PR DESCRIPTION
On 32-bit Windows a TextInput event receives multiple strange characters (after the first valid char), characters that, by default, cannot be rendered by a SpriteFont. These characters are strange, and they are different every time I start the game. This patch ignores these strange characters and just sends off the valid one. I remember reading somewhere on the SDL2 website that "the first character will always be what the client presses" - not sure if this is related to that. Ive tried searched thoroughly for this page but I am unable to find.

Ive actually had this fix for a while now for my own game, I thought it would be smart to get the fix here now ASAP so its ready for MonoGame repo merge

I will be attempting playing song's again soon as I see MonoGameSDL is making its move to the official repository, which I am very excited for :dancer: 
