### PR TITLE
Fix issue where calling Exit() hangs or throws InvalidOperationException

### DIFF
--- a/MonoGame.Framework/SDL2/SDL2_GamePlatform.cs
+++ b/MonoGame.Framework/SDL2/SDL2_GamePlatform.cs
@@ -150,6 +150,9 @@ namespace Microsoft.Xna.Framework
         
         public override void Exit()
         {
+            // Stop drawing
+            Game.SuppressDraw ();
+
             // Stop the game loop
             INTERNAL_window.INTERNAL_StopLoop();
             
@@ -158,6 +161,9 @@ namespace Microsoft.Xna.Framework
             
             // Close SDL2_mixer if needed
             Media.Song.closeMixer();
+
+            // Actually quit the game
+            SDL.SDL_Quit ();
         }
 
         public override bool BeforeUpdate(GameTime gameTime)


### PR DESCRIPTION
Just calling exit causes the monogame app to hang (unknown reason).
SDL.SDL_Quit() needs to be called to actually quit. However calling this
causes a System.InvalidOperationException to be thrown as the system is
still trying to draw to a destroyed window. This is fixed by calling
Game.SupressDraw() before we try and quit.
