### PR TITLE
Make Texture2D.GetData slightly less insulting to the spec.

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -681,14 +681,25 @@ namespace Microsoft.Xna.Framework.Graphics
 			if (glFormat == (GLPixelFormat)All.CompressedTextureFormats) {
 				throw new NotImplementedException();
 			} else {
-				if (rect.HasValue) {
+				Rectangle subRect = new Rectangle(0, 0, this.width, this.height);
+				if (rect.HasValue)
+				{
+					subRect.X = rect.Value.X;
+					subRect.Y = rect.Value.Y;
+					subRect.Width = rect.Value.Width;
+					subRect.Height = rect.Value.Height;
+				}
+				if (rect.HasValue && (rect.Value.X != 0 || rect.Value.Y != 0 || rect.Value.Width != this.width || rect.Value.Height != this.height)
+							|| startIndex != 0 || (elementCount >= subRect.Width*subRect.Height)) {
 					var temp = new T[this.width*this.height];
 					GL.GetTexImage(TextureTarget.Texture2D, level, this.glFormat, this.glType, temp);
 					int z = 0, w = 0;
 
-					for(int y= rect.Value.Y; y < rect.Value.Y+ rect.Value.Height; y++) {
-						for(int x=rect.Value.X; x < rect.Value.X + rect.Value.Width; x++) {
-							data[z*rect.Value.Width+w] = temp[(y*width)+x];
+					for(int y = subRect.Y; y < subRect.Y + subRect.Height; y++) {
+						for(int x = subRect.X; x < subRect.X + subRect.Width; x++) {
+							if (z*subRect.Width+w < startIndex) continue;
+							if (z*subRect.Width+w - startIndex >= elementCount) break;
+							data[z*subRect.Width+w-startIndex] = temp[(y*width)+x];
 							w++;
 						}
 						z++;


### PR DESCRIPTION
So it turns out that MonoGame's (OpenGL) implementation of Texture2D.GetData() ~~is a piece of shit~~ totally ignores two parameters, making it either:
a) Return the wrong results,
b) Throw an exception from trying to write outside the bounds of an array,
c) Make the GL driver corrupt memory _or_
d) Some combination of the above.

This fixes it to be spec-compliant, even if it's now a bit slower and the code is uglier (basically, we fall back to a now-even-slower slow path a lot more often).

This fixes one crash in Codename RobotnikNo, though this simply exposes another two seconds later. It also might be fixing a graphical issue, but the instancing is still sufficiently broken for me not to be able to tell.
