### PR TITLE
Give the GL driver some more info to optimize buffer uploads

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -2390,7 +2390,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     vertBuffer.VertexBuffer.VertexDeclaration.Apply(
                         _vertexShader,
-                        (IntPtr) (vertBuffer.VertexBuffer.VertexDeclaration.VertexStride * (vertBuffer.VertexOffset + baseVertex))
+                        (IntPtr) (vertBuffer.VertexBuffer.VertexDeclaration.VertexStride * (vertBuffer.VertexOffset))
                     );
                 }
             }
@@ -2406,13 +2406,14 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Draw!
-            GL.DrawRangeElements(
+            GL.DrawRangeElementsBaseVertex(
                 PrimitiveTypeGL(primitiveType),
 		minVertexIndex,
 		numVertices,
                 GetElementCountArray(primitiveType, primitiveCount),
                 shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt,
-                (IntPtr) (startIndex * (shortIndices ? 2 : 4))
+                (IntPtr) (startIndex * (shortIndices ? 2 : 4)),
+		baseVertex
             );
 
             // Check for errors in the debug context
@@ -2459,7 +2460,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     vertBuffer.VertexBuffer.VertexDeclaration.Apply(
                         _vertexShader,
-                        (IntPtr) (vertBuffer.VertexBuffer.VertexDeclaration.VertexStride * (vertBuffer.VertexOffset + baseVertex)),
+                        (IntPtr) (vertBuffer.VertexBuffer.VertexDeclaration.VertexStride * (vertBuffer.VertexOffset)),
                         vertBuffer.InstanceFrequency
                     );
                 }
@@ -2476,12 +2477,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Draw!
-            GL.DrawElementsInstanced(
+            GL.DrawElementsInstancedBaseVertex(
                 PrimitiveTypeGL(primitiveType),
                 GetElementCountArray(primitiveType, primitiveCount),
                 shortIndices ? DrawElementsType.UnsignedShort : DrawElementsType.UnsignedInt,
                 (IntPtr) (startIndex * (shortIndices ? 2 : 4)),
-                instanceCount
+                instanceCount,
+		baseVertex
             );
 
             // Check for errors in the debug context
@@ -2656,10 +2658,11 @@ namespace Microsoft.Xna.Framework.Graphics
             INTERNAL_FlushVertexAttributes();
 
             //Draw
-            GL.DrawElements(    PrimitiveTypeGL(primitiveType),
-                                GetElementCountArray(primitiveType, primitiveCount),
-                                DrawElementsType.UnsignedShort,
-                                (IntPtr)(ibHandle.AddrOfPinnedObject().ToInt64() + (indexOffset * sizeof(short))));
+            GL.DrawRangeElements(    PrimitiveTypeGL(primitiveType),
+	                             0, numVertices,
+                                     GetElementCountArray(primitiveType, primitiveCount),
+                                     DrawElementsType.UnsignedShort,
+                                     (IntPtr)(ibHandle.AddrOfPinnedObject().ToInt64() + (indexOffset * sizeof(short))));
             GraphicsExtensions.CheckGLError();
 
             // Release the handles.
@@ -2724,10 +2727,11 @@ namespace Microsoft.Xna.Framework.Graphics
             INTERNAL_FlushVertexAttributes();
 
             //Draw
-            GL.DrawElements(    PrimitiveTypeGL(primitiveType),
-                                GetElementCountArray(primitiveType, primitiveCount),
-                                DrawElementsType.UnsignedInt,
-                                (IntPtr)(ibHandle.AddrOfPinnedObject().ToInt64() + (indexOffset * sizeof(int))));
+            GL.DrawRangeElements(    PrimitiveTypeGL(primitiveType),
+	                             0, numVertices,
+                                     GetElementCountArray(primitiveType, primitiveCount),
+                                     DrawElementsType.UnsignedInt,
+                                     (IntPtr)(ibHandle.AddrOfPinnedObject().ToInt64() + (indexOffset * sizeof(int))));
             GraphicsExtensions.CheckGLError();
 
             // Release the handles.


### PR DESCRIPTION
Codename RobotnikNo (on Intel/Mesa at least) triggers a number of performance warnings about buffers still being in-use when glBufferSubData is called, requiring the driver to create a temp. buffer to store the contents and later blit that into the right part of the original buffer when it's no longer in use.

These patches try (not entirely successfully) to alleviate the problem by using glDrawRangeElements instead of glDrawElements to hint to the driver what parts of the buffer are in use. They also use the *BaseVertex variants of the draw calls to let the driver optimize that if possible.

It turns out this doesn't increase performance noticeably on my machine (largely because there's a huge performance issue with Parallel.ForEach<> which is overshadowing any benefit one could get from these smaller improvements), and it does require the GL_EXT_draw_range_elements and GL_ARB_draw_elements_base_vertex extensions. I don't think this is a big deal (Mesa has supported them since forever, and I doubt anything that can do instancing won't have them), but I understand if you'd rather not take the chance. I'd write fallbacks, but OpenTK's GL bindings give me a headache.

Tried it with both RobotnikNo and Naddachance, no rendering issues or performance regressions.

— David
