### PR TITLE
Fix bug when ContentReader is not a MemoryStream & data needs processing

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -251,10 +251,10 @@ namespace Microsoft.Xna.Framework.Content
 						break;
 				}
 				
-				if (reader.BaseStream.GetType() != typeof(System.IO.MemoryStream))
+				if (levelData == null && reader.BaseStream.GetType() != typeof(System.IO.MemoryStream))
 				{
-					/* Presumably a FileStream? Just get the data...
-					 * In that situation, levelData should be null.
+					/* If the ContentReader is not backed by a
+					 * MemoryStream, we have to read the data in.
 					 */
 					levelData = reader.ReadBytes(levelDataSizeInBytes);
 				}


### PR DESCRIPTION
Missed this case before. When the ContentReader is _not_ backed by a MemoryStream, we're not guaranteed that levelData is null — it's entirely possible to, for example, load a DXT compressed texture from a FileStream on a system without the right GL extension, in which case we would've already read in levelData and decompressed it.

The documentation is really nice, btw! :)

— David
