### PR TITLE
Fixed locale issues in the vector classes' ConvertTo() methods

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1847,7 +1847,8 @@ namespace Microsoft.Xna.Framework
             if (destinationType == typeof(string))
             {
                 Color src = (Color) value;
-                return src.R + "," + src.B + "," + src.B + "," + src.A;
+                string sep = culture.NumberFormat.NumberGroupSeparator;
+                return src.R.ToString(culture) + sep + src.B.ToString(culture) + sep + src.B.ToString(culture) + sep + src.A.ToString(culture);
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Xna.Framework
             if (destinationType == typeof(string))
             {
                 Vector2 src = (Vector2) value;
-                return src.X + "," + src.Y;
+                return src.X.ToString(culture) + culture.NumberFormat.NumberGroupSeparator + src.Y.ToString(culture);
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -773,7 +773,8 @@ namespace Microsoft.Xna.Framework
             if (destinationType == typeof(string))
             {
                 Vector3 src = (Vector3) value;
-                return src.X + "," + src.Y + "," + src.Z;
+                string sep = culture.NumberFormat.NumberGroupSeparator;
+                return src.X.ToString(culture) + sep + src.Y.ToString(culture) + sep + src.Z.ToString(culture);
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -720,7 +720,8 @@ namespace Microsoft.Xna.Framework
             if (destinationType == typeof(string))
             {
                 Vector4 src = (Vector4) value;
-                return src.X + "," + src.Y + "," + src.Z + "," + src.W;
+                string sep = culture.NumberFormat.NumberGroupSeparator;
+                return src.X.ToString(culture) + sep + src.Y.ToString(culture) + sep + src.Z.ToString(culture) + sep + src.W.ToString(culture);
             }
             return base.ConvertTo(context, culture, value, destinationType);
         }


### PR DESCRIPTION
This could be regarded as a follow-up to #129.

This fixes the string output in Color.ConvertTo() and Vector{2,3,4}.ConvertTo(), by making the methods do what is advertised; that is, formatting a string representation of the vector with a specified CultureInfo.

This hasn't affected any titles I've come across thus far, but you just know some poor fellow would bump in it somewhere along the line.
