### PR TITLE
Texture2D.FromStream - 24-bit RGB Support

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -647,11 +647,11 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             SDL_Surface* surPtr = (SDL_Surface*)surface;
             SDL.SDL_PixelFormat* pixelFormatPtr = (SDL.SDL_PixelFormat*)surPtr->format;
-            // SurfaceFormat.Color is SDL_PIXELFORMAT_ARGB8888
-            if (pixelFormatPtr->format != SDL.SDL_PIXELFORMAT_ARGB8888)
+            // SurfaceFormat.Color is SDL_PIXELFORMAT_ABGR8888
+            if (pixelFormatPtr->format != SDL.SDL_PIXELFORMAT_ABGR8888)
             {
                 // create a copy
-                IntPtr convertedSurface = SDL.SDL_ConvertSurfaceFormat(surface, SDL.SDL_PIXELFORMAT_ARGB8888, 0);
+                IntPtr convertedSurface = SDL.SDL_ConvertSurfaceFormat(surface, SDL.SDL_PIXELFORMAT_ABGR8888, 0);
                 // free the old surface
                 SDL.SDL_FreeSurface(surface);
                 surface = convertedSurface;


### PR DESCRIPTION
I've added a method named INTERNAL_convertSurfaceFormat which calls SDL.SDL_ConvertSurfaceFormat to convert the surface if the pixel format is not SDL_PIXELFORMAT_ARGB8888 (which is SurfaceFormat.Color in XNA). This fixes flibitijibibo/MonoGame#137.
