### PR TITLE
Remove redundant import.

### DIFF
--- a/ThirdParty/Lidgren.Network/Lidgren.Network.SDL2.csproj
+++ b/ThirdParty/Lidgren.Network/Lidgren.Network.SDL2.csproj
@@ -119,7 +119,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SenderChannelBase.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This eliminates three warnings about Microsoft.targets.csharp already
having been imported when building FNA.
