### PR TITLE
Comment Cleanup - Content/*.cs

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -289,8 +289,9 @@ namespace Microsoft.Xna.Framework.Content
 		{
 			Debug.Assert(disposable != null, "The disposable is null!");
 
-			/* Avoid recording disposable objects twice. ReloadAsset will try to record the disposables again.
-			 * We don't know which asset recorded which disposable so just guard against storing multiple of the same instance.
+			/* Avoid recording disposable objects twice. ReloadAsset will try to record
+			 * the disposables again. We don't know which asset recorded which
+			 * disposable so just guard against storing multiple of the same instance.
 			 */
 			if (!disposableAssets.Contains(disposable))
 			{
@@ -302,8 +303,9 @@ namespace Microsoft.Xna.Framework.Content
 
 		#region Protected Dispose Method
 
-		/* If disposing is true, it was called explicitly and we should dispose managed objects.
-		 * If disposing is false, it was called by the finalizer and managed objects should not be disposed.
+		/* If disposing is true, it was called explicitly and we should dispose managed
+		 * objects. If disposing is false, it was called by the finalizer and managed
+		 * objects should not be disposed.
 		 */
 		protected virtual void Dispose(bool disposing)
 		{
@@ -408,7 +410,12 @@ namespace Microsoft.Xna.Framework.Content
 				assetName = Normalize<T>(assetName);
 				if (string.IsNullOrEmpty(assetName))
 				{
-					throw new ContentLoadException("Could not load " + originalAssetName + " asset as a non-content file!", ex);
+					throw new ContentLoadException(
+						"Could not load " +
+						originalAssetName +
+						" asset as a non-content file!",
+						ex
+					);
 				}
 				result = ReadRawAsset<T>(assetName, originalAssetName);
 				/* Because Raw Assets skip the ContentReader step, they need to have their
@@ -646,7 +653,7 @@ namespace Microsoft.Xna.Framework.Content
 			ContentReader reader;
 			if (compressed)
 			{
-				/* Decompress the xnb
+				/* Decompress the XNB
 				 * Thanks to ShinAli (https://bitbucket.org/alisci01/xnbdecompressor)
 				 */
 				int compressedSize = xnbLength - 14;
@@ -660,14 +667,14 @@ namespace Microsoft.Xna.Framework.Content
 
 				while (pos - startPos < compressedSize)
 				{
-					/* The compressed stream is seperated into blocks that will decompress
-					 * into 32kB or some other size if specified.
-					 * Normal, 32kB output blocks will have a short indicating the size
-					 * of the block before the block starts.
-					 * Blocks that have a defined output will be preceded by a byte of value
-					 * 0xFF (255), then a short indicating the output size and another
-					 * for the block size.
-					 * All shorts for these cases are encoded in big endian order.
+					/* The compressed stream is separated into blocks that will
+					 * decompress into 32kB or some other size if specified.
+					 * Normal, 32kB output blocks will have a short indicating
+					 * the size of the block before the block starts. Blocks
+					 * that have a defined output will be preceded by a byte of
+					 * value 0xFF (255), then a short indicating the output size
+					 * and another for the block size. All shorts for these
+					 * cases are encoded in big endian order.
 					 */
 					int hi = stream.ReadByte();
 					int lo = stream.ReadByte();
@@ -696,14 +703,16 @@ namespace Microsoft.Xna.Framework.Content
 					dec.Decompress(stream, block_size, decompressedStream, frame_size);
 					pos += block_size;
 					decodedBytes += frame_size;
-					/* Reset the position of the input just in case the bit buffer
-					 * read in some unused bytes
+					/* Reset the position of the input just in case the bit
+					 * buffer read in some unused bytes.
 					 */
 					stream.Seek(pos, SeekOrigin.Begin);
 				}
 				if (decompressedStream.Position != decompressedSize)
 				{
-					throw new ContentLoadException("Decompression of " + originalAssetName + " failed. ");
+					throw new ContentLoadException(
+						"Decompression of " + originalAssetName + " failed. "
+					);
 				}
 				decompressedStream.Seek(0, SeekOrigin.Begin);
 				reader = new ContentReader(

--- a/MonoGame.Framework/Content/ContentReader.cs
+++ b/MonoGame.Framework/Content/ContentReader.cs
@@ -136,8 +136,9 @@ namespace Microsoft.Xna.Framework.Content
 				Uri src = new Uri("file:///" + assetName.Replace(notSeparator, separator));
 				// Add the relative path to the external reference
 				Uri dst = new Uri(src, externalReference);
-				/* The uri now contains the path to the external reference within the content manager
-				 * Get the local path and skip the first character (the path separator)
+				/* The uri now contains the path to the external reference within the
+				 * content manager. Get the local path and skip the first character
+				 * (the path separator).
 				 */
 				return contentManager.Load<T>(dst.LocalPath.Substring(1));
 			}

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Content
 
 			foreach (string ext in extensions)
 			{
-				// Concat the file name with valid extensions
+				// Concatenate the file name with valid extensions.
 				string fileNamePlusExt = fileName + ext;
 				if (File.Exists(fileNamePlusExt))
 				{
@@ -122,19 +122,22 @@ namespace Microsoft.Xna.Framework.Content
 
 		protected ContentTypeReader() : base(typeof(T))
 		{
-			// Nothing
 		}
 
 		#endregion
 
 		#region Protected Read Methods
 
+		/// <summary>
+		/// Reads an object from the input stream.
+		/// </summary>
+		/// <param name="input">The input stream.</param>
+		/// <param name="existingInstance">
+		/// Existing instance of an object to receive the data, or null if a new object
+		/// instance should be created.
+		/// </param>
 		protected internal override object Read(ContentReader input, object existingInstance)
 		{
-			/* As per the documentation http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.content.contenttypereader.read.aspx
-			 * existingInstance
-			 * The object receiving the data, or null if a new instance of the object should be created.
-			 */
 			if (existingInstance == null)
 			{
 				return this.Read(input, default(T));

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -179,8 +179,11 @@ namespace Microsoft.Xna.Framework.Content
 						}
 						catch (TargetInvocationException ex)
 						{
-							/* If you are getting here, the Mono runtime is most likely not able to JIT the type.
-							 * In particular, MonoTouch needs help instantiating types that are only defined in strings in Xnb files.
+							/* If you are getting here, the Mono runtime
+							 * is most likely not able to JIT the type.
+							 * In particular, MonoTouch needs help
+							 * instantiating types that are only defined
+							 * in strings in Xnb files.
 							 */
 							throw new InvalidOperationException(
 								"Failed to get default constructor for ContentTypeReader.\n" +
@@ -276,7 +279,6 @@ namespace Microsoft.Xna.Framework.Content
 					"$1"
 				);
 			}
-			// TODO: For WinRT this is most likely broken!
 			preparedType = preparedType.Replace(
 				", Microsoft.Xna.Framework.Graphics",
 				string.Format(


### PR DESCRIPTION
Mostly just fixes for line-length and capitalization.
- There are still a number of overly long (non-comment) lines in
  ContentManager.cs and other Content files. I'm resisting the
  urge to fix most of them, as this is a comment cleanup pass.
- LzxDecoder.cs: This must have been assimilated after the code
  standardization sweep.  It could use a complete run-through for
  code formatting, but now the comments are standard.
