### PR TITLE
Fix DoNotIgnoreMethodResultRule

### DIFF
--- a/MonoGame.Framework/Audio/OpenALDevice.cs
+++ b/MonoGame.Framework/Audio/OpenALDevice.cs
@@ -57,15 +57,25 @@ namespace Microsoft.Xna.Framework.Audio
 
 		#endregion
 
-		#region Public Constructor
+		#region Public Initializer
 
-		public OpenALDevice()
+		public static void Initialize()
 		{
+			// We should only have one of these!
 			if (Instance != null)
 			{
 				throw new Exception("OpenALDevice already created!");
 			}
 
+			Instance = new OpenALDevice();
+		}
+
+		#endregion
+
+		#region Private Constructor
+
+		private OpenALDevice()
+		{
 			alDevice = Alc.OpenDevice(string.Empty);
 			if (CheckALCError("Could not open AL device") || alDevice == IntPtr.Zero)
 			{
@@ -103,8 +113,6 @@ namespace Microsoft.Xna.Framework.Audio
 
 			instancePool = new List<SoundEffectInstance>();
 			dynamicInstancePool = new List<DynamicSoundEffectInstance>();
-
-			Instance = this;
 		}
 
 		#endregion

--- a/MonoGame.Framework/Audio/SoundBank.cs
+++ b/MonoGame.Framework/Audio/SoundBank.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Xna.Framework.Audio
 				// SoundBank Name, unused
 				System.Text.Encoding.UTF8.GetString(
 					reader.ReadBytes(64), 0, 64
-				).Replace("\0", "");
+				);
 
 				// Parse WaveBank names
 				soundBankStream.Seek(waveBankNameTableOffset, SeekOrigin.Begin);

--- a/MonoGame.Framework/Graphics/OpenGLDevice.cs
+++ b/MonoGame.Framework/Graphics/OpenGLDevice.cs
@@ -556,17 +556,25 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Constructor
+		#region Public Initializer
 
-		public OpenGLDevice()
+		public static void Initialize()
 		{
 			// We should only have one of these!
 			if (Instance != null)
 			{
 				throw new Exception("OpenGLDevice already created!");
 			}
-			Instance = this;
 
+			Instance = new OpenGLDevice();
+		}
+
+		#endregion
+
+		#region Private Constructor
+
+		private OpenGLDevice()
+		{
 			// Load OpenGL entry points
 			GL.LoadAll();
 

--- a/MonoGame.Framework/SDL2/SDL2_GamePlatform.cs
+++ b/MonoGame.Framework/SDL2/SDL2_GamePlatform.cs
@@ -224,10 +224,10 @@ namespace Microsoft.Xna.Framework
 #endif
 
 			// Set up the OpenGL Device. Loads entry points.
-			new OpenGLDevice();
+			OpenGLDevice.Initialize();
 
 			// Create the OpenAL device
-			new OpenALDevice();
+			OpenALDevice.Initialize();
 
 			// Initialize Active Key List
 			keys = new List<Keys>();


### PR DESCRIPTION
Added Initialize methods to OpenGLDevice and OpenALDevice so they
don't rely on a public constructor for initialization. (Private
Constructor, Public static Initialize method).

Also removed an unneccessary String.Replace from the SoundBank.

This is for issue flibitijibibo/MonoGame#196.
