### PR TITLE
Added ISpriteBatch, Texture2D.FromByteArray, faster RenderTarget2D.GetDa...

### DIFF
--- a/MonoGame.Framework/Graphics/RenderTarget2D.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.cs
@@ -9,6 +9,7 @@
 
 #region Using Statements
 using System;
+using OpenTK.Graphics.OpenGL;
 #endregion
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -166,5 +167,35 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		#endregion
-	}
+
+        #region GetData Speedup
+        public override void GetData<T>(int level, Rectangle? rect, T[] data, int startIndex, int elementCount)
+        {
+#if OPENGL
+            RenderTargetBinding[] bindings = this.GraphicsDevice.GetRenderTargets();
+            bool isActiveTarget = bindings.Length == 1 && bindings[0].RenderTarget == this;
+
+            if (isActiveTarget)
+            {
+                // GL.ReadPixels should be faster than reading back from the render target if we are already bound
+                if (rect.HasValue)
+                {
+                    GL.ReadPixels(rect.Value.Left, rect.Value.Top, rect.Value.Width, rect.Value.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                }
+                else
+                {
+                    GL.ReadPixels(0, 0, this.Width, this.Height, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                }
+            }
+            else
+            {
+                base.GetData<T>(level, rect, data, startIndex, elementCount);
+            }
+#else
+            base.GetData<T>(level, rect, data, startIndex, elementCount);
+#endif
+
+        }
+        #endregion
+    }
 }

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -14,8 +14,23 @@ using System.Text;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    public interface ISpriteBatch
+    {
+        void Draw(Texture2D texture,
+            Vector4 destinationRectangle,
+            Rectangle? sourceRectangle,
+            Color color,
+            float rotation,
+            Vector2 origin,
+            SpriteEffects effect,
+            float depth,
+            bool autoFlush);
+
+        void FlushIfNeeded();
+    }
+
 	// TODO: Rewrite from scratch using DynamicVertexBuffer/DynamicIndexBuffer. -flibit
-	public class SpriteBatch : GraphicsResource
+    public class SpriteBatch : GraphicsResource, ISpriteBatch
 	{
 		#region Private Variables
 
@@ -681,7 +696,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
 		// Mark the end of a draw operation for Immediate SpriteSortMode.
-		internal void FlushIfNeeded()
+		public void FlushIfNeeded()
 		{
 			if (_sortMode == SpriteSortMode.Immediate)
 			{
@@ -711,9 +726,24 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		#endregion
 
-		#region Private Methods
+        #region ISpriteBatch
+        void ISpriteBatch.Draw(Texture2D texture,
+            Vector4 destinationRectangle,
+            Rectangle? sourceRectangle,
+            Color color,
+            float rotation,
+            Vector2 origin,
+            SpriteEffects effect,
+            float depth,
+            bool autoFlush)
+        {
+            this.DrawInternal(texture, destinationRectangle, sourceRectangle, color, rotation, origin, effect, depth, autoFlush);
+        }
+        #endregion
 
-		void Setup()
+        #region Private Methods
+
+        void Setup()
 		{
 			GraphicsDevice gd = GraphicsDevice;
 			gd.BlendState = _blendState;

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			);
 		}
 
-		public void GetData<T>(
+		public virtual void GetData<T>(
 			int level,
 			Rectangle? rect,
 			T[] data,


### PR DESCRIPTION
1) RenderTarget2D.GetData:  I updated this method to GL.ReadPixels if it is the currently bound RenderTarget.  This is immensely faster

2) Texture2D.FromByteArray:  This method allows for taking image byte data (gotten through Steam) and putting it into a Texture

3) MonoGame.cfg:  Allows you to make a config file to set the minimum OpenGL version and any required OpenGL extensions

4) ISpriteBatch:  This was added to allow you to write your own SpriteBatch but still utilize the DrawInto functionality of SpriteFont.  This is purely XNA extension and retains all the old behavior.
