### PR TITLE
Don't interpret SDL_TEXTINPUT text as UTF-16, it's UTF-8

### DIFF
--- a/src/SDL2/SDL2_GamePlatform.cs
+++ b/src/SDL2/SDL2_GamePlatform.cs
@@ -459,7 +459,16 @@ namespace Microsoft.Xna.Framework
 					else if (evt.type == SDL.SDL_EventType.SDL_TEXTINPUT && !INTERNAL_TextInputSuppress)
 					{
 						string text;
-						unsafe { text = new string((char*) evt.text.text); }
+
+						unsafe
+						{
+							var endPtr = evt.text.text;
+							while (*endPtr != 0) endPtr++;
+							var bytes = new byte[endPtr - evt.text.text];
+							System.Runtime.InteropServices.Marshal.Copy((IntPtr)evt.text.text, bytes, 0, bytes.Length);
+							text = System.Text.Encoding.UTF8.GetString(bytes);
+						}
+
 						if (text.Length > 0)
 						{
 							TextInputEXT.OnTextInput(text[0]);


### PR DESCRIPTION
Fix FNA to correctly read SDL_TEXTINPUT event as UTF-8. .NET's char works with UTF-16 internally so we need to do some memory juggling.

Before the change, when pressing the "é" key on my French keyboard, I got garbage, now I get the expected character.

I based the conversion on SDL2-CS's [LPUtf8StrMarshaler.MarshalNativeToManaged](https://github.com/flibitijibibo/SDL2-CS/blob/cbf996466db8b56c748b20250183b663ad3d6251/src/LPUtf8StrMarshaler.cs#L61).