### PR TITLE
Fix Matrix.ToString() value nesting

### DIFF
--- a/src/Matrix.cs
+++ b/src/Matrix.cs
@@ -322,19 +322,19 @@ namespace Microsoft.Xna.Framework
 				"{M11:" + M11.ToString() +
 				" M12:" + M12.ToString() +
 				" M13:" + M13.ToString() +
-				" M14:}" + M14.ToString() +
-				" {M21:" + M21.ToString() +
+				" M14:" + M14.ToString() +
+				"} {M21:" + M21.ToString() +
 				" M22:" + M22.ToString() +
 				" M23:" + M23.ToString() +
-				" M24:}" + M24.ToString() +
-				" {M31:" + M31.ToString() +
+				" M24:" + M24.ToString() +
+				"} {M31:" + M31.ToString() +
 				" M32:" + M32.ToString() +
 				" M33:" + M33.ToString() +
-				" M34:}" + M34.ToString() +
-				" {M41:" + M41.ToString() +
+				" M34:" + M34.ToString() +
+				"} {M41:" + M41.ToString() +
 				" M42:" + M42.ToString() +
 				" M43:" + M43.ToString() +
-				" M44:}" + M44.ToString()
+				" M44:" + M44.ToString() + "}"
 			);
 		}
 


### PR DESCRIPTION
Fixes Matrix.ToString() output:

    {M11:0,2 M12:0 M13:0 M14:}0 {M21:0 M22:0,2 M23:0 M24:}0 {M31:0 M32:0 M33:-0,0010001 M34:}0 {M41:0 M42:0 M43:-0,00010001 M44:}1 // wrong
    {M11:0,2 M12:0 M13:0 M14:0} {M21:0 M22:0,2 M23:0 M24:0} {M31:0 M32:0 M33:-0,0010001 M34:0} {M41:0 M42:0 M43:-0,00010001 M44:1} // right
