### PR TITLE
Ignore SoundEffectInstance.Play() if already playing

### DIFF
--- a/src/Audio/SoundEffectInstance.cs
+++ b/src/Audio/SoundEffectInstance.cs
@@ -280,8 +280,7 @@ namespace Microsoft.Xna.Framework.Audio
 		{
 			if (State != SoundState.Stopped && INTERNAL_alSource != 0) // FIXME: alSource check part of timer hack!
 			{
-				// FIXME: Is this XNA4 behavior?
-				Stop();
+				return;
 			}
 
 			if (INTERNAL_alSource != 0)


### PR DESCRIPTION
    // FIXME: Is this XNA4 behavior?

Nope :). When calling Play() on an already playing sound, XNA will just ignore the call.