### PR TITLE
Replace MonoGame.Framework in XNB type strings

### DIFF
--- a/src/Content/ContentTypeReaderManager.cs
+++ b/src/Content/ContentTypeReaderManager.cs
@@ -319,6 +319,13 @@ namespace Microsoft.Xna.Framework.Content
 					assemblyName
 				)
 			);
+			preparedType = preparedType.Replace(
+				", MonoGame.Framework",
+				string.Format(
+					", {0}",
+					assemblyName
+				)
+			);
 			return preparedType;
 		}
 


### PR DESCRIPTION
Fixes issue with loading content produced by MG content pipeline #265 