### PR TITLE
Audio device nullfix

### DIFF
--- a/src/Audio/AudioDevice.cs
+++ b/src/Audio/AudioDevice.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Audio
 			}
 			else
 			{
-				Renderers = new ReadOnlyCollection<RendererDetail>(null);
+				Renderers = new ReadOnlyCollection<RendererDetail>(new List<RendererDetail>());
 			}
 		}
 


### PR DESCRIPTION
Fixed a line that is run when there is no ALDevice. Can't pass null into the constructor of ReadOnlyCollection, or it crashes.