### PR TITLE
Store and revert to last window position when toggling fullscreen. 

### DIFF
--- a/src/SDL2/SDL2_GameWindow.cs
+++ b/src/SDL2/SDL2_GameWindow.cs
@@ -277,11 +277,9 @@ namespace Microsoft.Xna.Framework
 			}
 			else if (!INTERNAL_wantsFullscreen)
 			{
-				// Store the last window position
-				INTERNAL_lastWindowPosition = new Point(
-					prevBounds.Left - (prevBounds.Width / 2),
-					prevBounds.Top - (prevBounds.Height / 2)
-					);
+				// Store the window position before switching to fullscreen
+				INTERNAL_lastWindowPosition.X = prevBounds.Left - (prevBounds.Width / 2);
+				INTERNAL_lastWindowPosition.Y = prevBounds.Top - (prevBounds.Height / 2);
 
 				SDL.SDL_SetWindowPosition(
 					INTERNAL_sdlWindow,

--- a/src/SDL2/SDL2_GameWindow.cs
+++ b/src/SDL2/SDL2_GameWindow.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Xna.Framework
 
 			INTERNAL_isFullscreen = false;
 			INTERNAL_wantsFullscreen = false;
-            INTERNAL_lastWindowPosition = new Point(SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED);
+			INTERNAL_lastWindowPosition = new Point(SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED);
 		}
 
 		#endregion

--- a/src/SDL2/SDL2_GameWindow.cs
+++ b/src/SDL2/SDL2_GameWindow.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Xna.Framework
 
 		private string INTERNAL_deviceName;
 
+		private Point INTERNAL_lastWindowPosition;
+
 		#endregion
 
 		#region Internal Constructor
@@ -221,6 +223,7 @@ namespace Microsoft.Xna.Framework
 
 			INTERNAL_isFullscreen = false;
 			INTERNAL_wantsFullscreen = false;
+            INTERNAL_lastWindowPosition = new Point(SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED);
 		}
 
 		#endregion
@@ -268,12 +271,18 @@ namespace Microsoft.Xna.Framework
 				// If exiting fullscreen, just center the window on the desktop.
 				SDL.SDL_SetWindowPosition(
 					INTERNAL_sdlWindow,
-					SDL.SDL_WINDOWPOS_CENTERED,
-					SDL.SDL_WINDOWPOS_CENTERED
+					INTERNAL_lastWindowPosition.X,
+					INTERNAL_lastWindowPosition.Y
 				);
 			}
 			else if (!INTERNAL_wantsFullscreen)
 			{
+				// Store the last window position
+				INTERNAL_lastWindowPosition = new Point(
+					prevBounds.Left - (prevBounds.Width / 2),
+					prevBounds.Top - (prevBounds.Height / 2)
+					);
+
 				SDL.SDL_SetWindowPosition(
 					INTERNAL_sdlWindow,
 					Math.Max(


### PR DESCRIPTION
In XNA & Monogame the last window position is stored when switching back and forth between window and fullscreen.
Made the center the default state, while storing the position when going from window to fullscreen.
Only tested on windows. Let me know how you feel about it.