### PR TITLE
Fixes traveling windows for last "Store window position" PR.

### DIFF
--- a/src/SDL2/SDL2_GameWindow.cs
+++ b/src/SDL2/SDL2_GameWindow.cs
@@ -278,8 +278,8 @@ namespace Microsoft.Xna.Framework
 			else if (!INTERNAL_wantsFullscreen)
 			{
 				// Store the window position before switching to fullscreen
-				INTERNAL_lastWindowPosition.X = prevBounds.Left - (prevBounds.Width / 2);
-				INTERNAL_lastWindowPosition.Y = prevBounds.Top - (prevBounds.Height / 2);
+				INTERNAL_lastWindowPosition.X = prevBounds.X + ((prevBounds.Width - clientWidth) / 2);
+				INTERNAL_lastWindowPosition.Y = prevBounds.Y + ((prevBounds.Height - clientHeight) / 2);
 
 				SDL.SDL_SetWindowPosition(
 					INTERNAL_sdlWindow,

--- a/src/SDL2/SDL2_GameWindow.cs
+++ b/src/SDL2/SDL2_GameWindow.cs
@@ -284,11 +284,11 @@ namespace Microsoft.Xna.Framework
 				SDL.SDL_SetWindowPosition(
 					INTERNAL_sdlWindow,
 					Math.Max(
-						prevBounds.X + ((prevBounds.Width - clientWidth) / 2),
+						INTERNAL_lastWindowPosition.X,
 						0
 					),
 					Math.Max(
-						prevBounds.Y + ((prevBounds.Height - clientHeight) / 2),
+						INTERNAL_lastWindowPosition.Y,
 						0
 					)
 				);


### PR DESCRIPTION
I did not use the correct position formula which caused traveling windows in certain situations.
This one fixes it and as it basically uses the same formula as the set position a few lines lower.

Also replaced that calculation with the variable.